### PR TITLE
Rename supported_tools to building  etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Community Contribution Guide
+# Community Collaboration Guide
 
 This guide has been provided by Red Hat to assist enterprise projects in
 collaborating with upstream communities on documentation. For Red Hat, this
@@ -11,3 +11,11 @@ In addition to recommendations for Red Hat documentation teams, this guide
 provides best practices, templates, and content recommendations to upstream
 communities. These suggestions inform communities on how to prepare for Red
 Hat writers to collaborate on documentation.
+
+The guide is published at
+https://redhat-documentation.github.io/community-collaboration-guide/.
+
+## Contributing to the Community Collaboration Guide
+
+Contributing to the guide is described in
+https://redhat-documentation.github.io/community-collaboration-guide/#ccg-contributing-to-the-framework.

--- a/community/master.adoc
+++ b/community/master.adoc
@@ -1,4 +1,4 @@
-= Community Contribution Guide
+= Community Collaboration Guide
 Red Hat Customer Content Services
 :imagesdir: images
 :doctype: book

--- a/community/master.adoc
+++ b/community/master.adoc
@@ -24,9 +24,7 @@ include::topics/migrating_an_existing_repository.adoc[]
 
 include::topics/asciidoc.adoc[]
 
-include::topics/supported_tools.adoc[]
-
-//Rendering instructions here from issue 43
+include::topics/building.adoc[]
 
 include::topics/publishing.adoc[]
 

--- a/community/master.adoc
+++ b/community/master.adoc
@@ -18,17 +18,17 @@ include::topics/community_evaluation.adoc[]
 
 include::topics/structure.adoc[]
 
-include::topics/asciidoc.adoc[]
+include::topics/creating_a_new_repository.adoc[]
 
 include::topics/migrating_an_existing_repository.adoc[]
+
+include::topics/asciidoc.adoc[]
 
 include::topics/supported_tools.adoc[]
 
 //Rendering instructions here from issue 43
 
 include::topics/publishing.adoc[]
-
-include::topics/creating_a_new_repository.adoc[]
 
 include::topics/tips_and_tricks.adoc[]
 

--- a/redhat/master.adoc
+++ b/redhat/master.adoc
@@ -23,9 +23,7 @@ include::topics/migrating_an_existing_repository.adoc[]
 
 include::topics/asciidoc.adoc[]
 
-include::topics/supported_tools.adoc[]
-
-//Rendering instructions here from issue 43
+include::topics/building.adoc[]
 
 include::topics/publishing.adoc[]
 

--- a/redhat/master.adoc
+++ b/redhat/master.adoc
@@ -17,17 +17,17 @@ include::topics/community_evaluation.adoc[]
 
 include::topics/structure.adoc[]
 
-include::topics/asciidoc.adoc[]
+include::topics/creating_a_new_repository.adoc[]
 
 include::topics/migrating_an_existing_repository.adoc[]
+
+include::topics/asciidoc.adoc[]
 
 include::topics/supported_tools.adoc[]
 
 //Rendering instructions here from issue 43
 
 include::topics/publishing.adoc[]
-
-include::topics/creating_a_new_repository.adoc[]
 
 include::topics/tips_and_tricks.adoc[]
 

--- a/topics/asciidoc.adoc
+++ b/topics/asciidoc.adoc
@@ -104,11 +104,6 @@ ifdef::redhat[]
 You can use `ccutil` to build a local preview of your content in the same way as repositories that do not use this repository structure. The only difference is that the command must be run in the `redhat` brand directory where the master file is located instead of in the default content directory. Pantheon builds and build scripts must also be updated to specify the `redhat` brand directory.
 endif::redhat[]
 
-[[ccg-synchronizing-content]]
-=== Synchronizing Content
-
-Placeholder text.
-
 [[ccg-asciidoc-converter]]
 === AsciiDoc Converters
 

--- a/topics/asciidoc.adoc
+++ b/topics/asciidoc.adoc
@@ -61,49 +61,6 @@ The `ifdef` statement must be at the start of a new line, even for inline refere
 
 . Render the guide to verify that your attributes are appearing correctly.
 
-
-[[ccg-rendering-content]]
-=== Rendering Content
-
-ifdef::community[]
-When your source content is ready to be reviewed or published, you can render it into a display format that can be hosted on a website, included directly in a product, or otherwise accessed by your users. The recommended tool for rendering AsciiDoc into a display format is AsciiDoctor. AsciiDoctor is a fully open-source, Ruby-based implementation of AsciiDoc, and is also the tool that GitHub itself uses to render the content of files written in AsciiDoc.
-
-See the project home page for instructions on how to install AsciiDoctor on a variety of platforms:
-
-* http://asciidoctor.org/[http://asciidoctor.org/^]
-
-The following is the basic syntax for rendering content into a display format:
-
-[options="nowrap" subs="verbatim,quotes"]
-----
-$ asciidoctor master.adoc
-----
-
-This command creates a single HTML file of the same name and in the same directory as the specified master file. The master file does not need to be in the current working directory, and you can specify either a relative path or absolute path to it.
-
-In addition to this basic syntax, AsciiDoctor also provides a number of options that allow you to customize the location and format of the content that it renders.
-
-The following example outlines how to specify a custom output directory:
-
-[options="nowrap" subs="verbatim,quotes"]
-----
-$ asciidoctor -D ./output master.adoc
-----
-
-The following example outlines how to render the content as an article instead of as a book:
-
-[options="nowrap" subs="verbatim,quotes"]
-----
-$ asciidoctor -d article master.adoc
-----
-
-For additional examples, including instructions on how to render content in formats other than HTML such as PDF, EPUB3, and LaTeX, see link:http://asciidoctor.org/docs/render-documents/[How do I render a document?^] on the AsciiDoctor project home page.
-endif::community[]
-
-ifdef::redhat[]
-You can use `ccutil` to build a local preview of your content in the same way as repositories that do not use this repository structure. The only difference is that the command must be run in the `redhat` brand directory where the master file is located instead of in the default content directory. Pantheon builds and build scripts must also be updated to specify the `redhat` brand directory.
-endif::redhat[]
-
 [[ccg-asciidoc-converter]]
 === AsciiDoc Converters
 

--- a/topics/building.adoc
+++ b/topics/building.adoc
@@ -1,7 +1,49 @@
-[[ccg-supported-tools]]
-== Supported Tools
+[[ccg-building-content]]
+== Building Content
 
 Placeholder text.
+
+[[ccg-rendering-content-locally]]
+=== Rendering Content Locally
+
+ifdef::community[]
+When your source content is ready to be reviewed or published, you can render it into a display format that can be hosted on a website, included directly in a product, or otherwise accessed by your users. The recommended tool for rendering AsciiDoc into a display format is AsciiDoctor. AsciiDoctor is a fully open-source, Ruby-based implementation of AsciiDoc, and is also the tool that GitHub itself uses to render the content of files written in AsciiDoc.
+
+See the project home page for instructions on how to install AsciiDoctor on a variety of platforms:
+
+* http://asciidoctor.org/[http://asciidoctor.org/^]
+
+The following is the basic syntax for rendering content into a display format:
+
+[options="nowrap" subs="verbatim,quotes"]
+----
+$ asciidoctor master.adoc
+----
+
+This command creates a single HTML file of the same name and in the same directory as the specified master file. The master file does not need to be in the current working directory, and you can specify either a relative path or absolute path to it.
+
+In addition to this basic syntax, AsciiDoctor also provides a number of options that allow you to customize the location and format of the content that it renders.
+
+The following example outlines how to specify a custom output directory:
+
+[options="nowrap" subs="verbatim,quotes"]
+----
+$ asciidoctor -D ./output master.adoc
+----
+
+The following example outlines how to render the content as an article instead of as a book:
+
+[options="nowrap" subs="verbatim,quotes"]
+----
+$ asciidoctor -d article master.adoc
+----
+
+For additional examples, including instructions on how to render content in formats other than HTML such as PDF, EPUB3, and LaTeX, see link:http://asciidoctor.org/docs/render-documents/[How do I render a document?^] on the AsciiDoctor project home page.
+endif::community[]
+
+ifdef::redhat[]
+You can use `ccutil` to build a local preview of your content in the same way as repositories that do not use this repository structure. The only difference is that the command must be run in the `redhat` brand directory where the master file is located instead of in the default content directory. Pantheon builds and build scripts must also be updated to specify the `redhat` brand directory.
+endif::redhat[]
 
 [[ccg-asciibinder-tool]]
 === AsciiBinder

--- a/topics/contributing_to_the_framework.adoc
+++ b/topics/contributing_to_the_framework.adoc
@@ -3,16 +3,16 @@
 
 You can contribute to this project in two ways:
 
-* Propose changes to the template
+* Propose changes to the _Community Collaboration Guide_
 
 * Update the _Community Collaboration Guide_
 
 Subsequent sections provide details for conducting each activity.
 
 [[ccg--proposing-a-change]]
-=== Proposing a Change to the Template
+=== Proposing a Change to the Guide
 
-Currently, the best method for proposing a change to the template is to open an issue in the https://github.com/redhat-documentation/community-collaboration-guide[community-collaboration-guide] GitHub repository.
+Currently, the best method for proposing a change to the _Community Collaboration Guide_ is to open an issue in the https://github.com/redhat-documentation/community-collaboration-guide[community-collaboration-guide] GitHub repository.
 
 .Prerequisites
 
@@ -22,7 +22,7 @@ You must be a member of the GitHub `community-collaboration-guide` repository.
 
 . Navigate to the https://github.com/redhat-documentation/community-collaboration-guide/issues[*Issues*] tab and click *New issue.* The window for creating a new issue is displayed.
 
-. In the `Title` field, type a concise summary of the template change you are proposing.
+. In the `Title` field, type a concise summary of the Guide change you are proposing.
 
 . In the `Write` field, provide additional details, such as the "what, where, and why" of the modification.
 

--- a/topics/publishing.adoc
+++ b/topics/publishing.adoc
@@ -3,7 +3,6 @@
 
 Placeholder text.
 
-
 [[ccg-asciibinder]]
 === AsciiBinder
 
@@ -33,8 +32,6 @@ Reference:: http://asciibinder.org/latest/guides/user_guide.html#building-the-do
 === Microservices
 
 Placeholder text.
-
-Reference::https://placeholder.url[]
 
 [[ccg-travis-container]]
 === Using Travis CI and Asciidoctor Container to Publish to GitHub Pages


### PR DESCRIPTION
* Rename supported_tools to building 
  * Move rendering content in.
  * See #32.
* Further improve ToC based on #50
*  Be consistent in referring to the guide